### PR TITLE
Use unique_id instead of guid for id attribute

### DIFF
--- a/jsonfeed/core.py
+++ b/jsonfeed/core.py
@@ -97,8 +97,8 @@ class JSONFeed(SyndicationFeed):
         if item.get('link'):
             item_element['url'] = item.get('link')
 
-        if item.get('guid'):
-            item_element['id'] = item.get('guid')
+        if item.get('unique_id'):
+            item_element['id'] = item.get('unique_id')
 
         if item.get('author_name') or item.get('author_email') or \
            item.get('author_link'):

--- a/tests/test_jsonfeed.py
+++ b/tests/test_jsonfeed.py
@@ -24,7 +24,7 @@ class JSONFeedTest(unittest.TestCase):
         )
 
         self.feed.add_item(
-            guid='https://example.com/hello',
+            unique_id='https://example.com/hello',
             title='Hello',
             link='https://example.com/hello',
             external_url='https://mylesb.ca/',
@@ -76,7 +76,7 @@ class JSONFeedTest(unittest.TestCase):
             content_text='Hello, World!',
             link='https://example.com/hello',
             external_url='https://mylesb.ca/',
-            guid='https://example.com/hello',
+            unique_id='https://example.com/hello',
             author_name='Myles Braithwaite',
             author_email='myles@example.com',
             author_link='https://example.com/',
@@ -97,6 +97,8 @@ class JSONFeedTest(unittest.TestCase):
         ))
 
         self.assertEqual(item['title'], 'Hello, World!')
+
+        self.assertEqual(item['id'], 'https://example.com/hello')
 
         self.assertEqual(item['content_html'], '<p>Hello, World!</p>')
 


### PR DESCRIPTION
This makes JSONFeed consistent with the other SyndicationFeed sublcasses which use `unique_id` for the feed item id.