### PR TITLE
Fix: make dates rfc3339 compliant

### DIFF
--- a/jsonfeed/core.py
+++ b/jsonfeed/core.py
@@ -2,9 +2,9 @@ import datetime
 import json
 
 try:
-    from feedgenerator import SyndicationFeed
+    from feedgenerator import SyndicationFeed, rfc3339_date
 except ImportError:
-    from django.utils.feedgenerator import SyndicationFeed
+    from django.utils.feedgenerator import SyndicationFeed, rfc3339_date
 
 
 class JSONFeed(SyndicationFeed):
@@ -134,10 +134,10 @@ class JSONFeed(SyndicationFeed):
             }]
 
         if item.get('pubdate'):
-            item_element['date_published'] = item.get('pubdate')
+            item_element['date_published'] = rfc3339_date(item.get('pubdate'))
 
         if item.get('updateddate'):
-            item_element['date_modified'] = item.get('updateddate')
+            item_element['date_modified'] = rfc3339_date(item.get('updateddate'))
 
         if item.get('categories'):
             item_element['tags'] = item.get('categories')


### PR DESCRIPTION
JSON Feed requires that dates be in RFC 3339 format. This PR uses Django's feedgenerator`rfc3339_date()` method to ensure that is the case.

(Should probably add a test for this.)