### PR TITLE
Fix populating attachment from feedgenerator.Enclosure

### DIFF
--- a/jsonfeed/core.py
+++ b/jsonfeed/core.py
@@ -121,10 +121,9 @@ class JSONFeed(SyndicationFeed):
 
         for attachment in item.get('enclosures', []):
             item_element['attachments'] += [{
-                'url': attachment.get('enclosure_url'),
-                'size_in_bytes': attachment.get('enclosure_length'),
-                'mime_type': attachment.get('enclosure_mime_type'),
-                'duration_in_seconds': attachment.get('duration_in_seconds')
+                'url': attachment.url,
+                'size_in_bytes': attachment.length,
+                'mime_type': attachment.mime_type,
             }]
 
         if (item.get('enclosure_url') or item.get('enclosure_length')

--- a/tests/test_jsonfeed.py
+++ b/tests/test_jsonfeed.py
@@ -89,7 +89,8 @@ class JSONFeedTest(unittest.TestCase):
             enclosure_length=20,
             enclosure_mime_type='image/png',
             enclosures=[
-                Enclosure(url='https://example.com/hello/audio.mp3', length=20, mime_type='audio/mpeg')
+                Enclosure(url='https://example.com/hello/audio.mp3', length=20,
+                    mime_type='audio/mpeg')
             ]
         ))
 

--- a/tests/test_jsonfeed.py
+++ b/tests/test_jsonfeed.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+from feedgenerator import Enclosure
 
 
 class JSONFeedTest(unittest.TestCase):
@@ -88,11 +89,7 @@ class JSONFeedTest(unittest.TestCase):
             enclosure_length=20,
             enclosure_mime_type='image/png',
             enclosures=[
-                dict(
-                    enclosure_url='https://example.com/hello/audio.mp3',
-                    enclosure_length=20,
-                    enclosure_mime_type='audio/mpeg',
-                ),
+                Enclosure(url='https://example.com/hello/audio.mp3', length=20, mime_type='audio/mpeg')
             ]
         ))
 


### PR DESCRIPTION
I am getting an error trying to generate JSONFeed from an RSS feed with an enclosure:

`AttributeError: 'Enclosure' object has no attribute 'get'`

I believe the code modified by this PR is supposed to work with an instance of `feedgenerator.Enclosure` class, is that correct? But `Enclosure` is not a dictionary and does not provide an equivalent to JSONFeed's `duration_in_seconds` (see https://github.com/getpelican/feedgenerator/blob/6582cd4bb3949aad2d1aa7d96c2c90c1ba9cf954/feedgenerator/django/utils/feedgenerator.py#L209-L214)

This PR fixes the error for me.